### PR TITLE
correcting columns and typos

### DIFF
--- a/models/marts/jinja_tricks/hierarchy_model.sql
+++ b/models/marts/jinja_tricks/hierarchy_model.sql
@@ -76,7 +76,7 @@ WITH RECURSIVE
             MAX(LAYER_{{ i }}_ID) OVER (
                 PARTITION BY LAYER_{{ max_layer }}_ID, START_DATE, END_DATE
             ) AS {{ layer_titles[i] }}_ID,
-            MAX(LAYER_{{ i }}_ID) OVER (
+            MAX(LAYER_{{ i }}_NAME) OVER (
                 PARTITION BY LAYER_{{ max_layer }}_ID, START_DATE, END_DATE
             ) AS {{ layer_titles[i] }}_NAME
             {%- if not loop.last %},{%- endif -%}

--- a/models/staging/gsheets/_gsheets_staging__schema.yml
+++ b/models/staging/gsheets/_gsheets_staging__schema.yml
@@ -31,4 +31,4 @@ models:
           description: The first date of the reporting relationship
 
         - name: end_date
-          description: The fina date of the reporting relationship
+          description: The final date of the reporting relationship

--- a/models/staging/gsheets/_gsheets_staging__sources.yml
+++ b/models/staging/gsheets/_gsheets_staging__sources.yml
@@ -36,4 +36,4 @@ sources:
             description: The first date of the reporting relationship
 
           - name: end_date
-            description: The fina date of the reporting relationship
+            description: The final date of the reporting relationship

--- a/models/staging/gsheets/stg_gsheets_hierarchy_table.sql
+++ b/models/staging/gsheets/stg_gsheets_hierarchy_table.sql
@@ -6,6 +6,7 @@ SELECT
     ,   LAYER
     ,   MANAGER_ID
     ,   PARSE_DATE('%m/%d/%Y', START_DATE) AS START_DATE
-    ,   PARSE_DATE('%m/%d/%Y', END_DATE) AS END_DATE 
+    ,   PARSE_DATE('%m/%d/%Y', END_DATE) AS END_DATE
+    ,   _FIVETRAN_SYNCED
 FROM
         {{ source("gsheets","hierarchy_table") }}


### PR DESCRIPTION
I accidentally referenced an `ID` column when I meant to reference a `NAME` column. This screenshot shows that this code works correctly:

![image](https://github.com/FeatherAnalytics/data-blogging-tables/assets/154101154/7253323d-40bc-47c9-b754-a4a859eaa3c9)

Additionally, the yml files had some typos that are corrected by this PR.

Lastly, I'm bringing the `_FIVETRAN_SYNCED` column in from the Fivetran source to the `stg_gsheets_hierarchy_table` model. 